### PR TITLE
Specific requeue functionality

### DIFF
--- a/src/Hangfire.Core/BackgroundJobClientExtensions.cs
+++ b/src/Hangfire.Core/BackgroundJobClientExtensions.cs
@@ -434,13 +434,24 @@ namespace Hangfire
         /// <param name="fromState">Current state assertion, or null if unneeded.</param>
         /// <returns>True, if state change succeeded, otherwise false.</returns>
         public static bool Requeue(
-            [NotNull] this IBackgroundJobClient client, 
-            [NotNull] string jobId, 
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull] string jobId,
             [CanBeNull] string fromState)
         {
-            if (client == null) throw new ArgumentNullException(nameof(client));
+            return Requeue(client, jobId, fromState, null);
+        }
+
+        public static bool Requeue(
+            [NotNull] this IBackgroundJobClient client,
+            [NotNull] string jobId,
+            [CanBeNull] string fromState,
+            [CanBeNull] string queueName)
+        {
+            if (client == null) throw new ArgumentNullException("client");
 
             var state = new EnqueuedState();
+            if (!string.IsNullOrEmpty(queueName)) state.Queue = queueName;
+
             return client.ChangeState(jobId, state, fromState);
         }
 

--- a/src/Hangfire.Core/Dashboard/BatchCommandDispatcher.cs
+++ b/src/Hangfire.Core/Dashboard/BatchCommandDispatcher.cs
@@ -15,6 +15,7 @@
 // License along with Hangfire. If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using Hangfire.Dashboard.Resources;
@@ -42,7 +43,7 @@ namespace Hangfire.Dashboard
         {
             var jobIds = await context.Request.GetFormValuesAsync("jobs[]");
             var queueNameList = await context.Request.GetFormValuesAsync("queueName");
-            var queueName = queueNameList?[0];
+            var queueName = queueNameList.FirstOrDefault();
 
             if (jobIds.Count == 0)
             {

--- a/src/Hangfire.Core/Dashboard/BatchCommandDispatcher.cs
+++ b/src/Hangfire.Core/Dashboard/BatchCommandDispatcher.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Hangfire.Dashboard.Resources;
 
 namespace Hangfire.Dashboard
 {
@@ -40,6 +41,9 @@ namespace Hangfire.Dashboard
         public async Task Dispatch(DashboardContext context)
         {
             var jobIds = await context.Request.GetFormValuesAsync("jobs[]");
+            var queueNameList = await context.Request.GetFormValuesAsync("queueName");
+            var queueName = queueNameList?[0];
+
             if (jobIds.Count == 0)
             {
                 context.Response.StatusCode = 422;
@@ -48,7 +52,15 @@ namespace Hangfire.Dashboard
 
             foreach (var jobId in jobIds)
             {
-                _command(context, jobId);
+                if (!string.IsNullOrEmpty(queueName))
+                {
+                    var jobIdAndQueue = $@"{jobId}:{queueName}";
+                    _command(context, jobIdAndQueue);
+                }
+                else
+                {
+                    _command(context, jobId);
+                }
             }
 
             context.Response.StatusCode = (int)HttpStatusCode.NoContent;

--- a/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
+++ b/src/Hangfire.Core/Dashboard/Content/css/hangfire.css
@@ -31,6 +31,18 @@ body {
 /* Custom page CSS
 -------------------------------------------------- */
 
+li { cursor: pointer; cursor: hand; }
+
+.noselect {
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none;   /* Chrome/Safari/Opera */
+  -khtml-user-select: none;    /* Konqueror */
+  -moz-user-select: none;      /* Firefox */
+  -ms-user-select: none;       /* Internet Explorer/Edge */
+  user-select: none;           /* Non-prefixed version, currently
+                                  not supported by any browser */
+}
+
 .container .credit {
   margin: 20px 0;
 }

--- a/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
+++ b/src/Hangfire.Core/Dashboard/Content/js/hangfire.js
@@ -393,6 +393,9 @@
                     
                     $('.js-jobs-list-command', container)
                         .prop('disabled', state === 'none-selected');
+
+                    $('.js-jobs-list-select', container)
+                        .prop('disabled', state === 'none-selected');
                 };
 
                 var updateListState = function() {
@@ -446,6 +449,8 @@
                     var $this = $(this);
                     var confirmText = $this.data('confirm');
 
+                    var queueName = this.id;
+
                     var jobs = $("input[name='jobs[]']:checked", container).map(function() {
                         return $(this).val();
                     }).get();
@@ -455,7 +460,7 @@
                             $this.button('loading');
                         }, 100);
 
-                        $.post($this.data('url'), { 'jobs[]': jobs }, function () {
+                        $.post($this.data('url'), { 'jobs[]': jobs, 'queueName': queueName }, function () {
                             clearTimeout(loadingDelay);
                             $this.button('reset');
                             window.location.reload();

--- a/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
+++ b/src/Hangfire.Core/Dashboard/DashboardRoutes.cs
@@ -111,6 +111,10 @@ namespace Hangfire.Dashboard
                 "/jobs/processing/requeue",
                 (client, jobId) => client.Requeue(jobId, ProcessingState.StateName));
 
+            Routes.AddClientBatchCommand(
+                "/jobs/processing/specificrequeue",
+                (client, jobIdAndQueue) => client.Requeue(jobIdAndQueue.Split(new char[] { ':' })[0], ProcessingState.StateName, jobIdAndQueue.Split(new char[] { ':' })[1]));
+
             Routes.AddRazorPage("/jobs/scheduled", x => new ScheduledJobsPage());
 
             Routes.AddClientBatchCommand(
@@ -126,11 +130,19 @@ namespace Hangfire.Dashboard
                 "/jobs/succeeded/requeue",
                 (client, jobId) => client.Requeue(jobId, SucceededState.StateName));
 
+            Routes.AddClientBatchCommand(
+                "/jobs/succeeded/specificrequeue",
+                (client, jobIdAndQueue) => client.Requeue(jobIdAndQueue.Split(new char[] { ':' })[0], SucceededState.StateName, jobIdAndQueue.Split(new char[] { ':' })[1]));
+
             Routes.AddRazorPage("/jobs/failed", x => new FailedJobsPage());
 
             Routes.AddClientBatchCommand(
                 "/jobs/failed/requeue",
                 (client, jobId) => client.Requeue(jobId, FailedState.StateName));
+
+            Routes.AddClientBatchCommand(
+                "/jobs/failed/specificrequeue",
+                (client, jobIdAndQueue) => client.Requeue(jobIdAndQueue.Split(new char[] { ':' })[0], FailedState.StateName, jobIdAndQueue.Split(new char[] { ':' })[1]));
 
             Routes.AddClientBatchCommand(
                 "/jobs/failed/delete",
@@ -141,6 +153,10 @@ namespace Hangfire.Dashboard
             Routes.AddClientBatchCommand(
                 "/jobs/deleted/requeue",
                 (client, jobId) => client.Requeue(jobId, DeletedState.StateName));
+
+            Routes.AddClientBatchCommand(
+                "/jobs/deleted/specificrequeue",
+                (client, jobIdAndQueue) => client.Requeue(jobIdAndQueue.Split(new char[] { ':' })[0], DeletedState.StateName, jobIdAndQueue.Split(new char[] { ':' })[1]));
 
             Routes.AddRazorPage("/jobs/awaiting", x => new AwaitingJobsPage());
             Routes.AddClientBatchCommand("/jobs/awaiting/enqueue", (client, jobId) => client.ChangeState(

--- a/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.cshtml
@@ -14,6 +14,7 @@
     var monitor = Storage.GetMonitoringApi();
     var pager = new Pager(from, perPage, monitor.DeletedListCount());
     var jobs = monitor.DeletedJobs(pager.FromRecord, pager.RecordsPerPage);
+    var servers = monitor.Servers();
 }
 
 <div class="row">
@@ -33,13 +34,49 @@
         {
             <div class="js-jobs-list">
                 <div class="btn-toolbar btn-toolbar-top">
-                    <button class="js-jobs-list-command btn btn-sm btn-primary"
-                            data-url="@Url.To("/jobs/deleted/requeue")"
-                            data-loading-text="@Strings.Common_Enqueueing"
-                            disabled="disabled">
-                        <span class="glyphicon glyphicon-repeat"></span>
-                        @Strings.Common_RequeueJobs
-                    </button>
+                    @if (SpecificJobRequeue == true)
+                    {
+                        <div class="btn-group">
+                            <button data-toggle="dropdown" data-target="#advanced-requeue-dropdown"
+                                    class="js-jobs-list-select btn dropdown-toggle btn-sm btn-primary"
+                                    aria-haspopup="true" aria-expanded="false" disabled="disabled">
+                                <span class="glyphicon glyphicon-repeat"></span>
+                                @Strings.Common_RequeueJobs
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="js-jobs-list-command noselect" data-url="@Url.To("/jobs/deleted/requeue")">
+                                        Default queue
+                                    </a>
+                                </li>
+                                <li class="divider" role="separator"></li>
+                                @foreach (var server in servers)
+                                {
+                                    <li class="noselect dropdown-header">@(server.Name.ToUpperInvariant().Split(':')[0])</li>
+                                    foreach (var queue in server.Queues)
+                                    {
+                                        <li>
+                                            <a class="noselect js-jobs-list-command"
+                                               data-url="@Url.To("/jobs/deleted/specificrequeue")"
+                                               id="@queue">
+                                                @queue
+                                            </a>
+                                        </li>
+                                    }
+                                }
+                            </ul>
+                        </div>
+                    }
+                    else
+                    {
+                        <button class="js-jobs-list-command btn btn-sm btn-primary"
+                                data-url="@Url.To("/jobs/deleted/requeue")"
+                                data-loading-text="@Strings.Common_Enqueueing"
+                                disabled="disabled">
+                            <span class="glyphicon glyphicon-repeat"></span>
+                            @Strings.Common_RequeueJobs
+                        </button>
+                    }
                     @Html.PerPageSelector(pager)
                 </div>
                 <div class="table-responsive">

--- a/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/DeletedJobsPage.generated.cs
@@ -63,6 +63,7 @@ WriteLiteral("\r\n");
     var monitor = Storage.GetMonitoringApi();
     var pager = new Pager(from, perPage, monitor.DeletedListCount());
     var jobs = monitor.DeletedJobs(pager.FromRecord, pager.RecordsPerPage);
+    var servers = monitor.Servers();
 
 
             
@@ -72,7 +73,7 @@ WriteLiteral("\r\n<div class=\"row\">\r\n    <div class=\"col-md-3\">\r\n       
 
 
             
-            #line 21 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 22 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
    Write(Html.JobsSidebar());
 
             
@@ -82,7 +83,7 @@ WriteLiteral("\r\n    </div>\r\n    <div class=\"col-md-9\">\r\n        <h1 clas
 
 
             
-            #line 24 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 25 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                            Write(Strings.DeletedJobsPage_Title);
 
             
@@ -92,7 +93,7 @@ WriteLiteral("</h1>\r\n\r\n");
 
 
             
-            #line 26 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 27 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
          if (pager.TotalPageCount == 0)
         {
 
@@ -103,7 +104,7 @@ WriteLiteral("            <div class=\"alert alert-info\">\r\n                ")
 
 
             
-            #line 29 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 30 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
            Write(Strings.DeletedJobsPage_NoJobs);
 
             
@@ -113,7 +114,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 31 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 32 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
         }
         else
         {
@@ -122,43 +123,182 @@ WriteLiteral("\r\n            </div>\r\n");
             #line default
             #line hidden
 WriteLiteral("            <div class=\"js-jobs-list\">\r\n                <div class=\"btn-toolbar b" +
-"tn-toolbar-top\">\r\n                    <button class=\"js-jobs-list-command btn bt" +
-"n-sm btn-primary\"\r\n                            data-url=\"");
+"tn-toolbar-top\">\r\n");
 
 
             
             #line 37 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
-                                 Write(Url.To("/jobs/deleted/requeue"));
+                     if (SpecificJobRequeue == true)
+                    {
 
             
             #line default
             #line hidden
-WriteLiteral("\"\r\n                            data-loading-text=\"");
+WriteLiteral(@"                        <div class=""btn-group"">
+                            <button data-toggle=""dropdown"" data-target=""#advanced-requeue-dropdown""
+                                    class=""js-jobs-list-select btn dropdown-toggle btn-sm btn-primary""
+                                    aria-haspopup=""true"" aria-expanded=""false"" disabled=""disabled"">
+                                <span class=""glyphicon glyphicon-repeat""></span>
+                                ");
 
 
             
-            #line 38 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
-                                          Write(Strings.Common_Enqueueing);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\"\r\n                            disabled=\"disabled\">\r\n                        <spa" +
-"n class=\"glyphicon glyphicon-repeat\"></span>\r\n                        ");
-
-
-            
-            #line 41 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
-                   Write(Strings.Common_RequeueJobs);
+            #line 44 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                           Write(Strings.Common_RequeueJobs);
 
             
             #line default
             #line hidden
-WriteLiteral("\r\n                    </button>\r\n                    ");
+WriteLiteral("\r\n                            </button>\r\n                            <ul class=\"d" +
+"ropdown-menu\">\r\n                                <li>\r\n                          " +
+"          <a class=\"js-jobs-list-command noselect\" data-url=\"");
 
 
             
-            #line 43 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 48 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                                                                  Write(Url.To("/jobs/deleted/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                        Default queue\r\n                      " +
+"              </a>\r\n                                </li>\r\n                     " +
+"           <li class=\"divider\" role=\"separator\"></li>\r\n");
+
+
+            
+            #line 53 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                 foreach (var server in servers)
+                                {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                    <li class=\"noselect dropdown-header\">");
+
+
+            
+            #line 55 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                                                     Write(server.Name.ToUpperInvariant().Split(':')[0]);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("</li>\r\n");
+
+
+            
+            #line 56 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                    foreach (var queue in server.Queues)
+                                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                        <li>\r\n                                   " +
+"         <a class=\"noselect js-jobs-list-command\"\r\n                             " +
+"                  data-url=\"");
+
+
+            
+            #line 60 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                                    Write(Url.To("/jobs/deleted/specificrequeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                               id=\"");
+
+
+            
+            #line 61 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                              Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                                ");
+
+
+            
+            #line 62 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                           Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                                            </a>\r\n                             " +
+"           </li>\r\n");
+
+
+            
+            #line 65 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                    }
+                                }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                            </ul>\r\n                        </div>\r\n");
+
+
+            
+            #line 69 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                    }
+                    else
+                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                        <button class=\"js-jobs-list-command btn btn-sm btn-primar" +
+"y\"\r\n                                data-url=\"");
+
+
+            
+            #line 73 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                     Write(Url.To("/jobs/deleted/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                data-loading-text=\"");
+
+
+            
+            #line 74 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                                              Write(Strings.Common_Enqueueing);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                disabled=\"disabled\">\r\n                        " +
+"    <span class=\"glyphicon glyphicon-repeat\"></span>\r\n                          " +
+"  ");
+
+
+            
+            #line 77 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                       Write(Strings.Common_RequeueJobs);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                        </button>\r\n");
+
+
+            
+            #line 79 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+                    }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                    ");
+
+
+            
+            #line 80 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                Write(Html.PerPageSelector(pager));
 
             
@@ -177,7 +317,7 @@ WriteLiteral(@"
 
 
             
-            #line 52 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 89 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                  Write(Strings.Common_Id);
 
             
@@ -187,7 +327,7 @@ WriteLiteral("</th>\r\n                                <th>");
 
 
             
-            #line 53 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 90 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                Write(Strings.Common_Job);
 
             
@@ -197,7 +337,7 @@ WriteLiteral("</th>\r\n                                <th class=\"align-right\"
 
 
             
-            #line 54 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 91 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                    Write(Strings.DeletedJobsPage_Table_Deleted);
 
             
@@ -208,7 +348,7 @@ WriteLiteral("</th>\r\n                            </tr>\r\n                    
 
 
             
-            #line 58 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 95 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                              foreach (var job in jobs)
                             {
 
@@ -219,7 +359,7 @@ WriteLiteral("                                <tr class=\"js-jobs-list-row ");
 
 
             
-            #line 60 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 97 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                         Write(job.Value == null || !job.Value.InDeletedState ? "obsolete-data" : null);
 
             
@@ -229,7 +369,7 @@ WriteLiteral(" ");
 
 
             
-            #line 60 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 97 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                                                                                                    Write(job.Value != null && job.Value.InDeletedState && job.Value != null ? "hover" : null);
 
             
@@ -239,7 +379,7 @@ WriteLiteral("\">\r\n                                    <td>\r\n");
 
 
             
-            #line 62 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 99 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                          if (job.Value == null || job.Value.InDeletedState)
                                         {
 
@@ -251,7 +391,7 @@ WriteLiteral("                                            <input type=\"checkbox
 
 
             
-            #line 64 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 101 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                                                                                  Write(job.Key);
 
             
@@ -261,7 +401,7 @@ WriteLiteral("\" />\r\n");
 
 
             
-            #line 65 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 102 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                         }
 
             
@@ -272,7 +412,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 68 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 105 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                    Write(Html.JobIdLink(job.Key));
 
             
@@ -282,7 +422,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 69 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 106 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                          if (job.Value != null && !job.Value.InDeletedState)
                                         {
 
@@ -293,7 +433,7 @@ WriteLiteral("                                            <span title=\"");
 
 
             
-            #line 71 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 108 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                     Write(Strings.Common_JobStateChanged_Text);
 
             
@@ -303,7 +443,7 @@ WriteLiteral("\" class=\"glyphicon glyphicon-question-sign\"></span>\r\n");
 
 
             
-            #line 72 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 109 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                         }
 
             
@@ -313,7 +453,7 @@ WriteLiteral("                                    </td>\r\n\r\n");
 
 
             
-            #line 75 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 112 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                      if (job.Value == null)
                                     {
 
@@ -324,7 +464,7 @@ WriteLiteral("                                        <td colspan=\"2\"><em>");
 
 
             
-            #line 77 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 114 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                        Write(Strings.Common_JobExpired);
 
             
@@ -334,7 +474,7 @@ WriteLiteral("</em></td>\r\n");
 
 
             
-            #line 78 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 115 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                     }
                                     else
                                     {
@@ -347,7 +487,7 @@ WriteLiteral("                                        <td>\r\n                  
 
 
             
-            #line 82 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 119 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                        Write(Html.JobNameLink(job.Key, job.Value.Job));
 
             
@@ -361,7 +501,7 @@ WriteLiteral("                                        <td class=\"align-right\">
 
 
             
-            #line 85 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 122 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                              if (job.Value.DeletedAt.HasValue)
                                             {
                                                 
@@ -369,14 +509,14 @@ WriteLiteral("                                        <td class=\"align-right\">
             #line default
             #line hidden
             
-            #line 87 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 124 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                            Write(Html.RelativeTime(job.Value.DeletedAt.Value));
 
             
             #line default
             #line hidden
             
-            #line 87 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 124 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                                                                              
                                             }
 
@@ -387,7 +527,7 @@ WriteLiteral("                                        </td>\r\n");
 
 
             
-            #line 90 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 127 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                                     }
 
             
@@ -397,7 +537,7 @@ WriteLiteral("                                </tr>\r\n");
 
 
             
-            #line 92 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 129 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
                             }
 
             
@@ -408,7 +548,7 @@ WriteLiteral("                        </tbody>\r\n                    </table>\r
 
 
             
-            #line 97 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 134 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
            Write(Html.Paginator(pager));
 
             
@@ -418,7 +558,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 99 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
+            #line 136 "..\..\Dashboard\Pages\DeletedJobsPage.cshtml"
         }
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.cshtml
@@ -15,6 +15,7 @@
     var monitor = Storage.GetMonitoringApi();
     var pager = new Pager(from, perPage, monitor.FailedCount());
     var failedJobs = monitor.FailedJobs(pager.FromRecord, pager.RecordsPerPage);
+    var servers = monitor.Servers();
 }
 
 <div class="row">
@@ -38,13 +39,49 @@
             
             <div class="js-jobs-list">
                 <div class="btn-toolbar btn-toolbar-top">
-                    <button class="js-jobs-list-command btn btn-sm btn-primary"
-                            data-url="@Url.To("/jobs/failed/requeue")"
-                            data-loading-text="@Strings.Common_Enqueueing"
-                            disabled="disabled">
-                        <span class="glyphicon glyphicon-repeat"></span>
-                        @Strings.Common_RequeueJobs
-                    </button>
+                    @if (SpecificJobRequeue == true)
+                    {
+                        <div class="btn-group">
+                            <button data-toggle="dropdown" data-target="#advanced-requeue-dropdown"
+                                    class="js-jobs-list-select btn dropdown-toggle btn-sm btn-primary"
+                                    aria-haspopup="true" aria-expanded="false" disabled="disabled">
+                                <span class="glyphicon glyphicon-repeat"></span>
+                                @Strings.Common_RequeueJobs
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="js-jobs-list-command noselect" data-url="@Url.To("/jobs/failed/requeue")">
+                                        Default queue
+                                    </a>
+                                </li>
+                                <li class="divider" role="separator"></li>
+                                @foreach (var server in servers)
+                                {
+                                    <li class="noselect dropdown-header">@(server.Name.ToUpperInvariant().Split(':')[0])</li>
+                                    foreach (var queue in server.Queues)
+                                    {
+                                        <li>
+                                            <a class="noselect js-jobs-list-command"
+                                               data-url="@Url.To("/jobs/failed/specificrequeue")"
+                                               id="@queue">
+                                                @queue
+                                            </a>
+                                        </li>
+                                    }
+                                }
+                            </ul>
+                        </div>
+                    }
+                    else
+                    {
+                        <button class="js-jobs-list-command btn btn-sm btn-primary"
+                                data-url="@Url.To("/jobs/failed/requeue")"
+                                data-loading-text="@Strings.Common_Enqueueing"
+                                disabled="disabled">
+                            <span class="glyphicon glyphicon-repeat"></span>
+                            @Strings.Common_RequeueJobs
+                        </button>
+                    }
 
                     <button class="js-jobs-list-command btn btn-sm btn-default"
                             data-url="@Url.To("/jobs/failed/delete")"

--- a/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/FailedJobsPage.generated.cs
@@ -69,6 +69,7 @@ WriteLiteral("\r\n");
     var monitor = Storage.GetMonitoringApi();
     var pager = new Pager(from, perPage, monitor.FailedCount());
     var failedJobs = monitor.FailedJobs(pager.FromRecord, pager.RecordsPerPage);
+    var servers = monitor.Servers();
 
 
             
@@ -78,7 +79,7 @@ WriteLiteral("\r\n<div class=\"row\">\r\n    <div class=\"col-md-3\">\r\n       
 
 
             
-            #line 22 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 23 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
    Write(Html.JobsSidebar());
 
             
@@ -88,7 +89,7 @@ WriteLiteral("\r\n    </div>\r\n    <div class=\"col-md-9\">\r\n        <h1 clas
 
 
             
-            #line 25 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 26 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                            Write(Strings.FailedJobsPage_Title);
 
             
@@ -98,7 +99,7 @@ WriteLiteral("</h1>\r\n\r\n");
 
 
             
-            #line 27 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 28 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
          if (pager.TotalPageCount == 0)
         {
 
@@ -109,7 +110,7 @@ WriteLiteral("            <div class=\"alert alert-success\">\r\n               
 
 
             
-            #line 30 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 31 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
           Write(Strings.FailedJobsPage_NoJobs);
 
             
@@ -119,7 +120,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 32 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 33 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
         }
         else
         {
@@ -131,7 +132,7 @@ WriteLiteral("            <div class=\"alert alert-warning\">\r\n               
 
 
             
-            #line 36 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 37 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
            Write(Html.Raw(Strings.FailedJobsPage_FailedJobsNotExpire_Warning_Html));
 
             
@@ -141,51 +142,190 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 38 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 39 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
             
 
             
             #line default
             #line hidden
 WriteLiteral("            <div class=\"js-jobs-list\">\r\n                <div class=\"btn-toolbar b" +
-"tn-toolbar-top\">\r\n                    <button class=\"js-jobs-list-command btn bt" +
-"n-sm btn-primary\"\r\n                            data-url=\"");
+"tn-toolbar-top\">\r\n");
 
 
             
             #line 42 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
-                                 Write(Url.To("/jobs/failed/requeue"));
+                     if (SpecificJobRequeue == true)
+                    {
 
             
             #line default
             #line hidden
-WriteLiteral("\"\r\n                            data-loading-text=\"");
+WriteLiteral(@"                        <div class=""btn-group"">
+                            <button data-toggle=""dropdown"" data-target=""#advanced-requeue-dropdown""
+                                    class=""js-jobs-list-select btn dropdown-toggle btn-sm btn-primary""
+                                    aria-haspopup=""true"" aria-expanded=""false"" disabled=""disabled"">
+                                <span class=""glyphicon glyphicon-repeat""></span>
+                                ");
 
 
             
-            #line 43 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
-                                          Write(Strings.Common_Enqueueing);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\"\r\n                            disabled=\"disabled\">\r\n                        <spa" +
-"n class=\"glyphicon glyphicon-repeat\"></span>\r\n                        ");
-
-
-            
-            #line 46 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
-                   Write(Strings.Common_RequeueJobs);
+            #line 49 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                           Write(Strings.Common_RequeueJobs);
 
             
             #line default
             #line hidden
-WriteLiteral("\r\n                    </button>\r\n\r\n                    <button class=\"js-jobs-lis" +
-"t-command btn btn-sm btn-default\"\r\n                            data-url=\"");
+WriteLiteral("\r\n                            </button>\r\n                            <ul class=\"d" +
+"ropdown-menu\">\r\n                                <li>\r\n                          " +
+"          <a class=\"js-jobs-list-command noselect\" data-url=\"");
 
 
             
-            #line 50 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 53 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                                                                  Write(Url.To("/jobs/failed/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                        Default queue\r\n                      " +
+"              </a>\r\n                                </li>\r\n                     " +
+"           <li class=\"divider\" role=\"separator\"></li>\r\n");
+
+
+            
+            #line 58 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                 foreach (var server in servers)
+                                {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                    <li class=\"noselect dropdown-header\">");
+
+
+            
+            #line 60 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                                                     Write(server.Name.ToUpperInvariant().Split(':')[0]);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("</li>\r\n");
+
+
+            
+            #line 61 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                    foreach (var queue in server.Queues)
+                                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                        <li>\r\n                                   " +
+"         <a class=\"noselect js-jobs-list-command\"\r\n                             " +
+"                  data-url=\"");
+
+
+            
+            #line 65 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                                    Write(Url.To("/jobs/failed/specificrequeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                               id=\"");
+
+
+            
+            #line 66 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                              Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                                ");
+
+
+            
+            #line 67 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                           Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                                            </a>\r\n                             " +
+"           </li>\r\n");
+
+
+            
+            #line 70 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                    }
+                                }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                            </ul>\r\n                        </div>\r\n");
+
+
+            
+            #line 74 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                    }
+                    else
+                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                        <button class=\"js-jobs-list-command btn btn-sm btn-primar" +
+"y\"\r\n                                data-url=\"");
+
+
+            
+            #line 78 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                     Write(Url.To("/jobs/failed/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                data-loading-text=\"");
+
+
+            
+            #line 79 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                                              Write(Strings.Common_Enqueueing);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                disabled=\"disabled\">\r\n                        " +
+"    <span class=\"glyphicon glyphicon-repeat\"></span>\r\n                          " +
+"  ");
+
+
+            
+            #line 82 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                       Write(Strings.Common_RequeueJobs);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                        </button>\r\n");
+
+
+            
+            #line 84 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+                    }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                    <button class=\"js-jobs-list-command btn btn-sm btn-default\"" +
+"\r\n                            data-url=\"");
+
+
+            
+            #line 87 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                  Write(Url.To("/jobs/failed/delete"));
 
             
@@ -195,7 +335,7 @@ WriteLiteral("\"\r\n                            data-loading-text=\"");
 
 
             
-            #line 51 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 88 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                           Write(Strings.Common_Deleting);
 
             
@@ -205,7 +345,7 @@ WriteLiteral("\"\r\n                            data-confirm=\"");
 
 
             
-            #line 52 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 89 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                      Write(Strings.Common_DeleteConfirm);
 
             
@@ -216,7 +356,7 @@ WriteLiteral("\">\r\n                        <span class=\"glyphicon glyphicon-r
 
 
             
-            #line 54 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 91 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                    Write(Strings.Common_DeleteSelected);
 
             
@@ -226,7 +366,7 @@ WriteLiteral("\r\n                    </button>\r\n\r\n                    ");
 
 
             
-            #line 57 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 94 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                Write(Html.PerPageSelector(pager));
 
             
@@ -246,7 +386,7 @@ WriteLiteral(@"
 
 
             
-            #line 67 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 104 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                  Write(Strings.Common_Id);
 
             
@@ -256,7 +396,7 @@ WriteLiteral("</th>\r\n                                <th>");
 
 
             
-            #line 68 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 105 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                Write(Strings.FailedJobsPage_Table_Failed);
 
             
@@ -266,7 +406,7 @@ WriteLiteral("</th>\r\n                                <th>");
 
 
             
-            #line 69 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 106 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                Write(Strings.Common_Job);
 
             
@@ -277,7 +417,7 @@ WriteLiteral("</th>\r\n                            </tr>\r\n                    
 
 
             
-            #line 73 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 110 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                var index = 0; 
 
             
@@ -285,7 +425,7 @@ WriteLiteral("</th>\r\n                            </tr>\r\n                    
             #line hidden
 
             
-            #line 74 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 111 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                              foreach (var job in failedJobs)
                             {
 
@@ -296,7 +436,7 @@ WriteLiteral("                                <tr class=\"js-jobs-list-row ");
 
 
             
-            #line 76 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 113 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                         Write(!job.Value.InFailedState ? "obsolete-data" : null);
 
             
@@ -306,7 +446,7 @@ WriteLiteral(" ");
 
 
             
-            #line 76 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 113 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                                                              Write(job.Value.InFailedState ? "hover" : null);
 
             
@@ -316,7 +456,7 @@ WriteLiteral("\">\r\n                                    <td rowspan=\"");
 
 
             
-            #line 77 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 114 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                              Write(job.Value.InFailedState ? "2" : "1");
 
             
@@ -326,7 +466,7 @@ WriteLiteral("\">\r\n");
 
 
             
-            #line 78 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 115 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                          if (job.Value.InFailedState)
                                         {
 
@@ -338,7 +478,7 @@ WriteLiteral("                                            <input type=\"checkbox
 
 
             
-            #line 80 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 117 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                                                                  Write(job.Key);
 
             
@@ -348,7 +488,7 @@ WriteLiteral("\" />\r\n");
 
 
             
-            #line 81 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 118 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                         }
 
             
@@ -359,7 +499,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 83 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 120 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                Write(job.Value.InFailedState ? "2" : "1");
 
             
@@ -369,7 +509,7 @@ WriteLiteral("\">\r\n                                        ");
 
 
             
-            #line 84 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 121 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                    Write(Html.JobIdLink(job.Key));
 
             
@@ -379,7 +519,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 85 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 122 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                          if (!job.Value.InFailedState)
                                         {
 
@@ -390,7 +530,7 @@ WriteLiteral("                                            <span title=\"");
 
 
             
-            #line 87 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 124 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                     Write(Strings.Common_JobStateChanged_Text);
 
             
@@ -400,7 +540,7 @@ WriteLiteral("\" class=\"glyphicon glyphicon-question-sign\"></span>\r\n");
 
 
             
-            #line 88 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 125 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                         }
 
             
@@ -411,7 +551,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 91 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 128 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                          if (job.Value.FailedAt.HasValue)
                                         {
                                             
@@ -419,14 +559,14 @@ WriteLiteral("                                    </td>\r\n                     
             #line default
             #line hidden
             
-            #line 93 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 130 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                        Write(Html.RelativeTime(job.Value.FailedAt.Value));
 
             
             #line default
             #line hidden
             
-            #line 93 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 130 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                                         
                                         }
 
@@ -439,7 +579,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 98 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 135 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                        Write(Html.JobNameLink(job.Key, job.Value.Job));
 
             
@@ -449,7 +589,7 @@ WriteLiteral("\r\n                                        </div>\r\n");
 
 
             
-            #line 100 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 137 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                          if (!String.IsNullOrEmpty(job.Value.ExceptionMessage))
                                         {
 
@@ -461,7 +601,7 @@ WriteLiteral("                                            <div style=\"color: #8
 
 
             
-            #line 103 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 140 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                            Write(job.Value.Reason);
 
             
@@ -471,7 +611,7 @@ WriteLiteral(" <a class=\"expander\" href=\"#\">");
 
 
             
-            #line 103 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 140 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                                            Write(index == 0 ? Strings.Common_LessDetails : Strings.Common_MoreDetails);
 
             
@@ -481,7 +621,7 @@ WriteLiteral("</a>\r\n                                            </div>\r\n");
 
 
             
-            #line 105 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 142 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                         }
 
             
@@ -492,7 +632,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 108 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 145 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                 if (job.Value.InFailedState)
                                 {
 
@@ -505,7 +645,7 @@ WriteLiteral("                                    <tr>\r\n                      
 
 
             
-            #line 112 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 149 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                        Write(index++ == 0 ? "display: block;" : null);
 
             
@@ -515,7 +655,7 @@ WriteLiteral("\">\r\n                                                <h4>");
 
 
             
-            #line 113 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 150 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                Write(job.Value.ExceptionType);
 
             
@@ -526,7 +666,7 @@ WriteLiteral("</h4>\r\n                                                <p class=
 
 
             
-            #line 115 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 152 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                Write(job.Value.ExceptionMessage);
 
             
@@ -536,7 +676,7 @@ WriteLiteral("\r\n                                                </p>\r\n\r\n")
 
 
             
-            #line 118 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 155 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                  if (!String.IsNullOrEmpty(job.Value.ExceptionDetails))
                                                 {
 
@@ -548,7 +688,7 @@ WriteLiteral("                                                    <pre class=\"s
 
 
             
-            #line 120 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 157 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                                               Write(Html.StackTrace(job.Value.ExceptionDetails));
 
             
@@ -558,7 +698,7 @@ WriteLiteral("</code></pre>\r\n");
 
 
             
-            #line 121 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 158 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                                 }
 
             
@@ -569,7 +709,7 @@ WriteLiteral("                                            </div>\r\n            
 
 
             
-            #line 125 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 162 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
                                 }
                             }
 
@@ -581,7 +721,7 @@ WriteLiteral("                        </tbody>\r\n                    </table>\r
 
 
             
-            #line 131 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 168 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
            Write(Html.Paginator(pager));
 
             
@@ -591,7 +731,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 133 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
+            #line 170 "..\..\Dashboard\Pages\FailedJobsPage.cshtml"
         }
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.cshtml
@@ -36,13 +36,49 @@
         {
             <div class="js-jobs-list">
                 <div class="btn-toolbar btn-toolbar-top">
-                    <button class="js-jobs-list-command btn btn-sm btn-primary"
-                            data-url="@Url.To("/jobs/processing/requeue")"
-                            data-loading-text="@Strings.Common_Enqueueing"
-                            disabled="disabled">
-                        <span class="glyphicon glyphicon-repeat"></span>
-                        @Strings.Common_RequeueJobs
-                    </button>
+                    @if (SpecificJobRequeue == true)
+                    {
+                        <div class="btn-group">
+                            <button data-toggle="dropdown" data-target="#advanced-requeue-dropdown"
+                                    class="js-jobs-list-select btn dropdown-toggle btn-sm btn-primary"
+                                    aria-haspopup="true" aria-expanded="false" disabled="disabled">
+                                <span class="glyphicon glyphicon-repeat"></span>
+                                @Strings.Common_RequeueJobs
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="js-jobs-list-command noselect" data-url="@Url.To("/jobs/processing/requeue")">
+                                        Default queue
+                                    </a>
+                                </li>
+                                <li class="divider" role="separator"></li>
+                                @foreach (var server in servers)
+                                {
+                                    <li class="noselect dropdown-header">@(server.Name.ToUpperInvariant().Split(':')[0])</li>
+                                    foreach (var queue in server.Queues)
+                                    {
+                                        <li>
+                                            <a class="noselect js-jobs-list-command"
+                                               data-url="@Url.To("/jobs/processing/specificrequeue")"
+                                               id="@queue">
+                                                @queue
+                                            </a>
+                                        </li>
+                                    }
+                                }
+                            </ul>
+                        </div>
+                    }
+                    else
+                    {
+                        <button class="js-jobs-list-command btn btn-sm btn-primary"
+                                data-url="@Url.To("/jobs/processing/requeue")"
+                                data-loading-text="@Strings.Common_Enqueueing"
+                                disabled="disabled">
+                            <span class="glyphicon glyphicon-repeat"></span>
+                            @Strings.Common_RequeueJobs
+                        </button>
+                    }
 
                     <button class="js-jobs-list-command btn btn-sm btn-default"
                             data-url="@Url.To("/jobs/processing/delete")"

--- a/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/ProcessingJobsPage.generated.cs
@@ -135,44 +135,183 @@ WriteLiteral("\r\n            </div>\r\n");
             #line default
             #line hidden
 WriteLiteral("            <div class=\"js-jobs-list\">\r\n                <div class=\"btn-toolbar b" +
-"tn-toolbar-top\">\r\n                    <button class=\"js-jobs-list-command btn bt" +
-"n-sm btn-primary\"\r\n                            data-url=\"");
+"tn-toolbar-top\">\r\n");
 
 
             
-            #line 40 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
-                                 Write(Url.To("/jobs/processing/requeue"));
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\"\r\n                            data-loading-text=\"");
-
-
-            
-            #line 41 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
-                                          Write(Strings.Common_Enqueueing);
+            #line 39 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                     if (SpecificJobRequeue == true)
+                    {
 
             
             #line default
             #line hidden
-WriteLiteral("\"\r\n                            disabled=\"disabled\">\r\n                        <spa" +
-"n class=\"glyphicon glyphicon-repeat\"></span>\r\n                        ");
+WriteLiteral(@"                        <div class=""btn-group"">
+                            <button data-toggle=""dropdown"" data-target=""#advanced-requeue-dropdown""
+                                    class=""js-jobs-list-select btn dropdown-toggle btn-sm btn-primary""
+                                    aria-haspopup=""true"" aria-expanded=""false"" disabled=""disabled"">
+                                <span class=""glyphicon glyphicon-repeat""></span>
+                                ");
 
 
             
-            #line 44 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
-                   Write(Strings.Common_RequeueJobs);
+            #line 46 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                           Write(Strings.Common_RequeueJobs);
 
             
             #line default
             #line hidden
-WriteLiteral("\r\n                    </button>\r\n\r\n                    <button class=\"js-jobs-lis" +
-"t-command btn btn-sm btn-default\"\r\n                            data-url=\"");
+WriteLiteral("\r\n                            </button>\r\n                            <ul class=\"d" +
+"ropdown-menu\">\r\n                                <li>\r\n                          " +
+"          <a class=\"js-jobs-list-command noselect\" data-url=\"");
 
 
             
-            #line 48 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 50 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                                                                  Write(Url.To("/jobs/processing/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                        Default queue\r\n                      " +
+"              </a>\r\n                                </li>\r\n                     " +
+"           <li class=\"divider\" role=\"separator\"></li>\r\n");
+
+
+            
+            #line 55 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                 foreach (var server in servers)
+                                {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                    <li class=\"noselect dropdown-header\">");
+
+
+            
+            #line 57 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                                                     Write(server.Name.ToUpperInvariant().Split(':')[0]);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("</li>\r\n");
+
+
+            
+            #line 58 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                    foreach (var queue in server.Queues)
+                                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                        <li>\r\n                                   " +
+"         <a class=\"noselect js-jobs-list-command\"\r\n                             " +
+"                  data-url=\"");
+
+
+            
+            #line 62 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                                    Write(Url.To("/jobs/processing/specificrequeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                               id=\"");
+
+
+            
+            #line 63 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                              Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                                ");
+
+
+            
+            #line 64 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                           Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                                            </a>\r\n                             " +
+"           </li>\r\n");
+
+
+            
+            #line 67 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                    }
+                                }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                            </ul>\r\n                        </div>\r\n");
+
+
+            
+            #line 71 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                    }
+                    else
+                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                        <button class=\"js-jobs-list-command btn btn-sm btn-primar" +
+"y\"\r\n                                data-url=\"");
+
+
+            
+            #line 75 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                     Write(Url.To("/jobs/processing/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                data-loading-text=\"");
+
+
+            
+            #line 76 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                                              Write(Strings.Common_Enqueueing);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                disabled=\"disabled\">\r\n                        " +
+"    <span class=\"glyphicon glyphicon-repeat\"></span>\r\n                          " +
+"  ");
+
+
+            
+            #line 79 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                       Write(Strings.Common_RequeueJobs);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                        </button>\r\n");
+
+
+            
+            #line 81 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+                    }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                    <button class=\"js-jobs-list-command btn btn-sm btn-default\"" +
+"\r\n                            data-url=\"");
+
+
+            
+            #line 84 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                  Write(Url.To("/jobs/processing/delete"));
 
             
@@ -182,7 +321,7 @@ WriteLiteral("\"\r\n                            data-loading-text=\"");
 
 
             
-            #line 49 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 85 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                           Write(Strings.Common_Deleting);
 
             
@@ -192,7 +331,7 @@ WriteLiteral("\"\r\n                            data-confirm=\"");
 
 
             
-            #line 50 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 86 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                      Write(Strings.Common_DeleteConfirm);
 
             
@@ -203,7 +342,7 @@ WriteLiteral("\"\r\n                            disabled=\"disabled\">\r\n      
 
 
             
-            #line 53 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 89 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                    Write(Strings.Common_DeleteSelected);
 
             
@@ -213,7 +352,7 @@ WriteLiteral("\r\n                    </button>\r\n\r\n                    ");
 
 
             
-            #line 56 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 92 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                Write(Html.PerPageSelector(pager));
 
             
@@ -233,7 +372,7 @@ WriteLiteral(@"
 
 
             
-            #line 66 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 102 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                  Write(Strings.Common_Id);
 
             
@@ -243,7 +382,7 @@ WriteLiteral("</th>\r\n                                <th class=\"min-width\">"
 
 
             
-            #line 67 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 103 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                  Write(Strings.Common_Server);
 
             
@@ -253,7 +392,7 @@ WriteLiteral("</th>\r\n                                <th>");
 
 
             
-            #line 68 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 104 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                Write(Strings.Common_Job);
 
             
@@ -263,7 +402,7 @@ WriteLiteral("</th>\r\n                                <th class=\"align-right\"
 
 
             
-            #line 69 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 105 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                    Write(Strings.ProcessingJobsPage_Table_Started);
 
             
@@ -274,7 +413,7 @@ WriteLiteral("</th>\r\n                            </tr>\r\n                    
 
 
             
-            #line 73 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 109 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                              foreach (var job in processingJobs)
                             {
 
@@ -285,7 +424,7 @@ WriteLiteral("                                <tr class=\"js-jobs-list-row ");
 
 
             
-            #line 75 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 111 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                         Write(!job.Value.InProcessingState ? "obsolete-data" : null);
 
             
@@ -295,7 +434,7 @@ WriteLiteral(" ");
 
 
             
-            #line 75 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 111 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                                                                                  Write(job.Value.InProcessingState ? "hover" : null);
 
             
@@ -305,7 +444,7 @@ WriteLiteral("\">\r\n                                    <td>\r\n");
 
 
             
-            #line 77 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 113 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                          if (job.Value.InProcessingState)
                                         {
 
@@ -317,7 +456,7 @@ WriteLiteral("                                            <input type=\"checkbox
 
 
             
-            #line 79 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 115 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                                                                                  Write(job.Key);
 
             
@@ -327,7 +466,7 @@ WriteLiteral("\" />\r\n");
 
 
             
-            #line 80 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 116 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                         }
 
             
@@ -338,7 +477,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 83 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 119 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                    Write(Html.JobIdLink(job.Key));
 
             
@@ -348,7 +487,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 84 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 120 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                          if (!job.Value.InProcessingState)
                                         {
 
@@ -359,7 +498,7 @@ WriteLiteral("                                            <span title=\"");
 
 
             
-            #line 86 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 122 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                     Write(Strings.Common_JobStateChanged_Text);
 
             
@@ -369,7 +508,7 @@ WriteLiteral("\" class=\"glyphicon glyphicon-question-sign\"></span>\r\n");
 
 
             
-            #line 87 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 123 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                         }
 
             
@@ -380,7 +519,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 90 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 126 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                    Write(Html.ServerId(job.Value.ServerId));
 
             
@@ -391,7 +530,7 @@ WriteLiteral("\r\n                                    </td>\r\n                 
 
 
             
-            #line 93 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 129 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                          if (servers.All(x => x.Name != job.Value.ServerId || x.Heartbeat < DateTime.UtcNow.AddMinutes(-1)))
                                         {
 
@@ -402,7 +541,7 @@ WriteLiteral("                                            <span title=\"");
 
 
             
-            #line 95 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 131 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                     Write(Strings.ProcessingJobsPage_Aborted);
 
             
@@ -412,7 +551,7 @@ WriteLiteral("\" class=\"glyphicon glyphicon-warning-sign\" style=\"font-size: 1
 
 
             
-            #line 96 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 132 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                         }
 
             
@@ -422,7 +561,7 @@ WriteLiteral("\r\n                                        ");
 
 
             
-            #line 98 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 134 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                    Write(Html.JobNameLink(job.Key, job.Value.Job));
 
             
@@ -433,7 +572,7 @@ WriteLiteral("\r\n                                    </td>\r\n                 
 
 
             
-            #line 101 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 137 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                          if (job.Value.StartedAt.HasValue)
                                         {
                                             
@@ -441,14 +580,14 @@ WriteLiteral("\r\n                                    </td>\r\n                 
             #line default
             #line hidden
             
-            #line 103 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 139 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                        Write(Html.RelativeTime(job.Value.StartedAt.Value));
 
             
             #line default
             #line hidden
             
-            #line 103 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 139 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                                                                                          
                                         }
 
@@ -460,7 +599,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 107 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 143 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
                             }
 
             
@@ -471,7 +610,7 @@ WriteLiteral("                        </tbody>\r\n                    </table>\r
 
 
             
-            #line 112 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 148 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
            Write(Html.Paginator(pager));
 
             
@@ -481,7 +620,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 114 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
+            #line 150 "..\..\Dashboard\Pages\ProcessingJobsPage.cshtml"
         }
 
             

--- a/src/Hangfire.Core/Dashboard/Pages/SucceededJobs.cshtml
+++ b/src/Hangfire.Core/Dashboard/Pages/SucceededJobs.cshtml
@@ -15,6 +15,7 @@
     var monitor = Storage.GetMonitoringApi();
     var pager = new Pager(from, perPage, monitor.SucceededListCount());
     var succeededJobs = monitor.SucceededJobs(pager.FromRecord, pager.RecordsPerPage);
+    var servers = monitor.Servers();
 }
 
 <div class="row">
@@ -34,13 +35,49 @@
         {
             <div class="js-jobs-list">
                 <div class="btn-toolbar btn-toolbar-top">
-                    <button class="js-jobs-list-command btn btn-sm btn-primary"
-                            data-url="@Url.To("/jobs/succeeded/requeue")"
-                            data-loading-text="@Strings.Common_Enqueueing"
-                            disabled="disabled">
-                        <span class="glyphicon glyphicon-repeat"></span>
-                        @Strings.Common_RequeueJobs
-                    </button>
+                    @if (SpecificJobRequeue == true)
+                    {
+                        <div class="btn-group">
+                            <button data-toggle="dropdown" data-target="#advanced-requeue-dropdown"
+                                    class="js-jobs-list-select btn dropdown-toggle btn-sm btn-primary"
+                                    aria-haspopup="true" aria-expanded="false" disabled="disabled">
+                                <span class="glyphicon glyphicon-repeat"></span>
+                                @Strings.Common_RequeueJobs
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="js-jobs-list-command noselect" data-url="@Url.To("/jobs/succeeded/requeue")">
+                                        Default queue
+                                    </a>
+                                </li>
+                                <li class="divider" role="separator"></li>
+                                @foreach (var server in servers)
+                                {
+                                    <li class="noselect dropdown-header">@(server.Name.ToUpperInvariant().Split(':')[0])</li>
+                                    foreach (var queue in server.Queues)
+                                    {
+                                        <li>
+                                            <a class="noselect js-jobs-list-command"
+                                               data-url="@Url.To("/jobs/succeeded/specificrequeue")"
+                                               id="@queue">
+                                                @queue
+                                            </a>
+                                        </li>
+                                    }
+                                }
+                            </ul>
+                        </div>
+                    }
+                    else
+                    {
+                        <button class="js-jobs-list-command btn btn-sm btn-primary"
+                                data-url="@Url.To("/jobs/succeeded/requeue")"
+                                data-loading-text="@Strings.Common_Enqueueing"
+                                disabled="disabled">
+                            <span class="glyphicon glyphicon-repeat"></span>
+                            @Strings.Common_RequeueJobs
+                        </button>
+                    }
 
                     @Html.PerPageSelector(pager)
                 </div>

--- a/src/Hangfire.Core/Dashboard/Pages/SucceededJobs1.generated.cs
+++ b/src/Hangfire.Core/Dashboard/Pages/SucceededJobs1.generated.cs
@@ -69,6 +69,7 @@ WriteLiteral("\r\n");
     var monitor = Storage.GetMonitoringApi();
     var pager = new Pager(from, perPage, monitor.SucceededListCount());
     var succeededJobs = monitor.SucceededJobs(pager.FromRecord, pager.RecordsPerPage);
+    var servers = monitor.Servers();
 
 
             
@@ -78,7 +79,7 @@ WriteLiteral("\r\n<div class=\"row\">\r\n    <div class=\"col-md-3\">\r\n       
 
 
             
-            #line 22 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 23 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
    Write(Html.JobsSidebar());
 
             
@@ -88,7 +89,7 @@ WriteLiteral("\r\n    </div>\r\n    <div class=\"col-md-9\">\r\n        <h1 clas
 
 
             
-            #line 25 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 26 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                            Write(Strings.SucceededJobsPage_Title);
 
             
@@ -98,7 +99,7 @@ WriteLiteral("</h1>\r\n\r\n");
 
 
             
-            #line 27 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 28 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
          if (pager.TotalPageCount == 0)
         {
 
@@ -109,7 +110,7 @@ WriteLiteral("            <div class=\"alert alert-info\">\r\n                ")
 
 
             
-            #line 30 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 31 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
            Write(Strings.SucceededJobsPage_NoJobs);
 
             
@@ -119,7 +120,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 32 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 33 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
         }
         else
         {
@@ -128,43 +129,182 @@ WriteLiteral("\r\n            </div>\r\n");
             #line default
             #line hidden
 WriteLiteral("            <div class=\"js-jobs-list\">\r\n                <div class=\"btn-toolbar b" +
-"tn-toolbar-top\">\r\n                    <button class=\"js-jobs-list-command btn bt" +
-"n-sm btn-primary\"\r\n                            data-url=\"");
+"tn-toolbar-top\">\r\n");
 
 
             
             #line 38 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
-                                 Write(Url.To("/jobs/succeeded/requeue"));
+                     if (SpecificJobRequeue == true)
+                    {
 
             
             #line default
             #line hidden
-WriteLiteral("\"\r\n                            data-loading-text=\"");
-
-
-            
-            #line 39 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
-                                          Write(Strings.Common_Enqueueing);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\"\r\n                            disabled=\"disabled\">\r\n                        <spa" +
-"n class=\"glyphicon glyphicon-repeat\"></span>\r\n                        ");
-
-
-            
-            #line 42 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
-                   Write(Strings.Common_RequeueJobs);
-
-            
-            #line default
-            #line hidden
-WriteLiteral("\r\n                    </button>\r\n\r\n                    ");
+WriteLiteral(@"                        <div class=""btn-group"">
+                            <button data-toggle=""dropdown"" data-target=""#advanced-requeue-dropdown""
+                                    class=""js-jobs-list-select btn dropdown-toggle btn-sm btn-primary""
+                                    aria-haspopup=""true"" aria-expanded=""false"" disabled=""disabled"">
+                                <span class=""glyphicon glyphicon-repeat""></span>
+                                ");
 
 
             
             #line 45 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                           Write(Strings.Common_RequeueJobs);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                            </button>\r\n                            <ul class=\"d" +
+"ropdown-menu\">\r\n                                <li>\r\n                          " +
+"          <a class=\"js-jobs-list-command noselect\" data-url=\"");
+
+
+            
+            #line 49 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                                                                  Write(Url.To("/jobs/succeeded/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                        Default queue\r\n                      " +
+"              </a>\r\n                                </li>\r\n                     " +
+"           <li class=\"divider\" role=\"separator\"></li>\r\n");
+
+
+            
+            #line 54 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                 foreach (var server in servers)
+                                {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                    <li class=\"noselect dropdown-header\">");
+
+
+            
+            #line 56 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                                                     Write(server.Name.ToUpperInvariant().Split(':')[0]);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("</li>\r\n");
+
+
+            
+            #line 57 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                    foreach (var queue in server.Queues)
+                                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                                        <li>\r\n                                   " +
+"         <a class=\"noselect js-jobs-list-command\"\r\n                             " +
+"                  data-url=\"");
+
+
+            
+            #line 61 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                                    Write(Url.To("/jobs/succeeded/specificrequeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                               id=\"");
+
+
+            
+            #line 62 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                              Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\">\r\n                                                ");
+
+
+            
+            #line 63 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                           Write(queue);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                                            </a>\r\n                             " +
+"           </li>\r\n");
+
+
+            
+            #line 66 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                    }
+                                }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                            </ul>\r\n                        </div>\r\n");
+
+
+            
+            #line 70 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                    }
+                    else
+                    {
+
+            
+            #line default
+            #line hidden
+WriteLiteral("                        <button class=\"js-jobs-list-command btn btn-sm btn-primar" +
+"y\"\r\n                                data-url=\"");
+
+
+            
+            #line 74 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                     Write(Url.To("/jobs/succeeded/requeue"));
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                data-loading-text=\"");
+
+
+            
+            #line 75 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                                              Write(Strings.Common_Enqueueing);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\"\r\n                                disabled=\"disabled\">\r\n                        " +
+"    <span class=\"glyphicon glyphicon-repeat\"></span>\r\n                          " +
+"  ");
+
+
+            
+            #line 78 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                       Write(Strings.Common_RequeueJobs);
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                        </button>\r\n");
+
+
+            
+            #line 80 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+                    }
+
+            
+            #line default
+            #line hidden
+WriteLiteral("\r\n                    ");
+
+
+            
+            #line 82 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                Write(Html.PerPageSelector(pager));
 
             
@@ -184,7 +324,7 @@ WriteLiteral(@"
 
 
             
-            #line 55 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 92 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                  Write(Strings.Common_Id);
 
             
@@ -194,7 +334,7 @@ WriteLiteral("</th>\r\n                                <th>");
 
 
             
-            #line 56 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 93 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                Write(Strings.Common_Job);
 
             
@@ -204,7 +344,7 @@ WriteLiteral("</th>\r\n                                <th class=\"min-width\">"
 
 
             
-            #line 57 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 94 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                  Write(Strings.SucceededJobsPage_Table_TotalDuration);
 
             
@@ -214,7 +354,7 @@ WriteLiteral("</th>\r\n                                <th class=\"align-right\"
 
 
             
-            #line 58 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 95 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                    Write(Strings.SucceededJobsPage_Table_Succeeded);
 
             
@@ -225,7 +365,7 @@ WriteLiteral("</th>\r\n                            </tr>\r\n                    
 
 
             
-            #line 62 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 99 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                              foreach (var job in succeededJobs)
                             {
 
@@ -236,7 +376,7 @@ WriteLiteral("                                <tr class=\"js-jobs-list-row ");
 
 
             
-            #line 64 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 101 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                         Write(job.Value == null || !job.Value.InSucceededState ? "obsolete-data" : null);
 
             
@@ -246,7 +386,7 @@ WriteLiteral(" ");
 
 
             
-            #line 64 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 101 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                                                                                                      Write(job.Value != null && job.Value.InSucceededState ? "hover" : null);
 
             
@@ -256,7 +396,7 @@ WriteLiteral("\">\r\n                                    <td>\r\n");
 
 
             
-            #line 66 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 103 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                          if (job.Value == null || job.Value.InSucceededState)
                                         {
 
@@ -268,7 +408,7 @@ WriteLiteral("                                            <input type=\"checkbox
 
 
             
-            #line 68 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 105 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                                                                                  Write(job.Key);
 
             
@@ -278,7 +418,7 @@ WriteLiteral("\" />\r\n");
 
 
             
-            #line 69 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 106 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                         }
 
             
@@ -289,7 +429,7 @@ WriteLiteral("                                    </td>\r\n                     
 
 
             
-            #line 72 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 109 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                    Write(Html.JobIdLink(job.Key));
 
             
@@ -299,7 +439,7 @@ WriteLiteral("\r\n");
 
 
             
-            #line 73 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 110 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                          if (job.Value != null && !job.Value.InSucceededState)
                                         {
 
@@ -310,7 +450,7 @@ WriteLiteral("                                            <span title=\"");
 
 
             
-            #line 75 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 112 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                     Write(Strings.Common_JobStateChanged_Text);
 
             
@@ -320,7 +460,7 @@ WriteLiteral("\" class=\"glyphicon glyphicon-question-sign\"></span>\r\n");
 
 
             
-            #line 76 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 113 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                         }
 
             
@@ -330,7 +470,7 @@ WriteLiteral("                                    </td>\r\n\r\n");
 
 
             
-            #line 79 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 116 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                      if (job.Value == null)
                                     {
 
@@ -342,7 +482,7 @@ WriteLiteral("                                        <td colspan=\"3\">\r\n    
 
 
             
-            #line 82 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 119 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                            Write(Strings.Common_JobExpired);
 
             
@@ -352,7 +492,7 @@ WriteLiteral("</em>\r\n                                        </td>\r\n");
 
 
             
-            #line 84 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 121 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                     }
                                     else
                                     {
@@ -365,7 +505,7 @@ WriteLiteral("                                        <td>\r\n                  
 
 
             
-            #line 88 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 125 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                        Write(Html.JobNameLink(job.Key, job.Value.Job));
 
             
@@ -379,7 +519,7 @@ WriteLiteral("                                        <td class=\"min-width alig
 
 
             
-            #line 91 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 128 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                              if (job.Value.TotalDuration.HasValue)
                                             {
                                                 
@@ -387,14 +527,14 @@ WriteLiteral("                                        <td class=\"min-width alig
             #line default
             #line hidden
             
-            #line 93 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 130 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                            Write(Html.ToHumanDuration(TimeSpan.FromMilliseconds(job.Value.TotalDuration.Value), false));
 
             
             #line default
             #line hidden
             
-            #line 93 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 130 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                                                                                                       
                                             }
 
@@ -409,7 +549,7 @@ WriteLiteral("                                        <td class=\"min-width alig
 
 
             
-            #line 97 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 134 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                              if (job.Value.SucceededAt.HasValue)
                                             {
                                                 
@@ -417,14 +557,14 @@ WriteLiteral("                                        <td class=\"min-width alig
             #line default
             #line hidden
             
-            #line 99 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 136 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                            Write(Html.RelativeTime(job.Value.SucceededAt.Value));
 
             
             #line default
             #line hidden
             
-            #line 99 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 136 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                                                                                
                                             }
 
@@ -435,7 +575,7 @@ WriteLiteral("                                        </td>\r\n");
 
 
             
-            #line 102 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 139 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                                     }
 
             
@@ -445,7 +585,7 @@ WriteLiteral("                                </tr>\r\n");
 
 
             
-            #line 104 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 141 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
                             }
 
             
@@ -456,7 +596,7 @@ WriteLiteral("                        </tbody>\r\n                    </table>\r
 
 
             
-            #line 109 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 146 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
            Write(Html.Paginator(pager));
 
             
@@ -466,7 +606,7 @@ WriteLiteral("\r\n            </div>\r\n");
 
 
             
-            #line 111 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
+            #line 148 "..\..\Dashboard\Pages\SucceededJobs.cshtml"
         }
 
             

--- a/src/Hangfire.Core/Dashboard/RazorPage.cs
+++ b/src/Hangfire.Core/Dashboard/RazorPage.cs
@@ -43,6 +43,7 @@ namespace Hangfire.Dashboard
         public string AppPath { get; internal set; }
         public int StatsPollingInterval { get; internal set; }
         public Stopwatch GenerationTime { get; private set; }
+        public bool SpecificJobRequeue { get; private set; }
 
         public StatisticsDto Statistics
         {
@@ -78,6 +79,8 @@ namespace Hangfire.Dashboard
             Response = parentPage.Response;
             Storage = parentPage.Storage;
             AppPath = parentPage.AppPath;
+            SpecificJobRequeue = parentPage.SpecificJobRequeue;
+
             StatsPollingInterval = parentPage.StatsPollingInterval;
             Url = parentPage.Url;
 
@@ -93,6 +96,8 @@ namespace Hangfire.Dashboard
             Storage = context.Storage;
             AppPath = context.Options.AppPath;
             StatsPollingInterval = context.Options.StatsPollingInterval;
+            SpecificJobRequeue = context.Options.SpecificJobRequeue;
+
             Url = new UrlHelper(context);
 
             _statisticsLazy = new Lazy<StatisticsDto>(() =>

--- a/src/Hangfire.Core/DashboardOptions.cs
+++ b/src/Hangfire.Core/DashboardOptions.cs
@@ -27,12 +27,14 @@ namespace Hangfire
             AppPath = "/";
             Authorization = new[] { new LocalRequestsOnlyAuthorizationFilter() };
             StatsPollingInterval = 2000;
+            SpecificJobRequeue = false;
         }
 
         /// <summary>
         /// The path for the Back To Site link. Set to <see langword="null" /> in order to hide the Back To Site link.
         /// </summary>
         public string AppPath { get; set; }
+        public bool SpecificJobRequeue { get; set; }
 
 #if NETFULL
         [Obsolete("Please use `Authorization` property instead. Will be removed in 2.0.0.")]


### PR DESCRIPTION
Feature #5

Added the ability to re-queue jobs onto specific queues via a drop-down menu on the dashboard. 

This change maintains the current behaviour for re-queuing jobs at the top of the drop-down, as well as adding re-queuing options for each available queue, sorted by server.

This is can be included in the dashboard through DashboardOptions, as shown in the example below.
By default, the specific re-queue is disabled, to retain original functionality.

```
app.UseHangfireDashboard("/hangfire", new DashboardOptions()
{
     SpecificJobRequeue = true
});

```

Files changed:

```
Hangfire.Core
   BackgroundJobClientExtensions.cs
   DashboardOptions.cs
   Dashboard/
      DashboardRoutes.cs
      RazorPage.cs
      BatchCommandDispatcher.cs
      Content/
         js, css
      Pages/
         html
```

**No _interface_ breaking changes.**
